### PR TITLE
Fix vendored deps so that cargo test works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ build/
 !gradle/wrapper/*.jar
 
 target/
-Dockerfile
+#Dockerfile

--- a/vendor/cargo-tarpaulin/Dockerfile
+++ b/vendor/cargo-tarpaulin/Dockerfile
@@ -1,0 +1,27 @@
+FROM rust as builder
+
+WORKDIR /opt/tarpaulin
+
+RUN env USER=root cargo init .
+
+COPY Cargo.toml .
+COPY Cargo.lock .
+COPY build.rs .
+
+RUN mkdir .cargo
+RUN cargo vendor > .cargo/config
+
+COPY src /opt/tarpaulin/src
+
+RUN cd /opt/tarpaulin/ && \
+    cargo install --locked --path . && \
+    rm -rf /opt/tarpaulin/ && \
+    rm -rf /usr/local/cargo/registry/
+
+FROM rust
+
+COPY --from=builder /usr/local/cargo/bin/cargo-tarpaulin /usr/local/cargo/bin/cargo-tarpaulin
+
+WORKDIR /volume
+
+CMD cargo build && cargo tarpaulin

--- a/vendor/libssh2-sys/libssh2/tests/openssh_server/Dockerfile
+++ b/vendor/libssh2-sys/libssh2/tests/openssh_server/Dockerfile
@@ -1,0 +1,82 @@
+# Copyright (c) 2016 Alexander Lamaison <alexander.lamaison@gmail.com>
+#
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
+# that the following conditions are met:
+#
+#   Redistributions of source code must retain the above
+#   copyright notice, this list of conditions and the
+#   following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above
+#   copyright notice, this list of conditions and the following
+#   disclaimer in the documentation and/or other materials
+#   provided with the distribution.
+#
+#   Neither the name of the copyright holder nor the names
+#   of any other contributors may be used to endorse or
+#   promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+# OF SUCH DAMAGE.
+
+FROM debian:jessie
+
+RUN apt-get update \
+ && apt-get install -y openssh-server \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+RUN mkdir /var/run/sshd
+
+# Chmodding because, when building on Windows, files are copied in with
+# -rwxr-xr-x permissions.
+#
+# Copying to a temp location, then moving because chmodding the copied file has
+# no effect (Docker AUFS-related bug maybe?)
+COPY ssh_host_rsa_key /tmp/etc/ssh/ssh_host_rsa_key
+RUN mv /tmp/etc/ssh/ssh_host_rsa_key /etc/ssh/ssh_host_rsa_key
+RUN chmod 600 /etc/ssh/ssh_host_rsa_key
+
+COPY ssh_host_ecdsa_key /tmp/etc/ssh/ssh_host_ecdsa_key
+RUN mv /tmp/etc/ssh/ssh_host_ecdsa_key /etc/ssh/ssh_host_ecdsa_key
+RUN chmod 600 /etc/ssh/ssh_host_ecdsa_key
+
+COPY ssh_host_ed25519_key /tmp/etc/ssh/ssh_host_ed25519_key
+RUN mv /tmp/etc/ssh/ssh_host_ed25519_key /etc/ssh/ssh_host_ed25519_key
+RUN chmod 600 /etc/ssh/ssh_host_ed25519_key
+
+RUN adduser --disabled-password --gecos 'Test user for libssh2 integration tests' libssh2
+RUN echo 'libssh2:my test password' | chpasswd
+
+RUN sed -i 's/ChallengeResponseAuthentication no/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config
+
+# SSH login fix. Otherwise user is kicked off after login
+RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+
+USER libssh2
+
+RUN mkdir -p /home/libssh2/.ssh
+RUN mkdir -p /home/libssh2/sandbox
+
+COPY authorized_keys /tmp/libssh2/.ssh/authorized_keys
+RUN cp /tmp/libssh2/.ssh/authorized_keys /home/libssh2/.ssh/authorized_keys
+RUN chmod 600 /home/libssh2/.ssh/authorized_keys
+
+USER root
+
+EXPOSE 22
+# -e gives logs via 'docker logs'
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/vendor/libz-sys/ci/Dockerfile
+++ b/vendor/libz-sys/ci/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:18.04
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+  gcc \
+  libc6-dev \
+  ca-certificates
+


### PR DESCRIPTION
The `.gitignore` file ignores `Dockerfile` which causes vendored deps, several of which contain these files, not to have their complete contents. Therefore `cargo test` fails when it tries to checksum the vendored deps. This fixes the issue.